### PR TITLE
chore: disable credit card

### DIFF
--- a/assets/application.json
+++ b/assets/application.json
@@ -40,6 +40,12 @@
     "products/variations/price": []
   },
   "admin_settings": {
+    "disable": {
+      "type": "boolean",
+      "default": false,
+      "title": "Desabilitar cartão de crédido",
+      "description": "Desabilitar cartão de crédito via MP"
+    },
     "label": {
       "schema": {
         "type": "string",

--- a/assets/application.json
+++ b/assets/application.json
@@ -43,8 +43,7 @@
     "disable": {
       "type": "boolean",
       "default": false,
-      "title": "Desabilitar cartão de crédido",
-      "description": "Desabilitar cartão de crédito via MP"
+      "title": "Desabilitar cartão de crédido"
     },
     "label": {
       "schema": {


### PR DESCRIPTION
Parece que já existe em list payments uma propriedade para desabilitar o cartão de crédito pelo que li:
https://github.com/ecomplus/app-mercadopago/blob/master/functions/routes/ecom/modules/list-payments.js#L83

  ;['credit_card', 'banking_billet'].forEach(paymentMethod => {
    const isCreditCard = paymentMethod === 'credit_card'
    const methodConfig = isCreditCard ? config : config[paymentMethod]
    if (methodConfig && (methodConfig.enable || (isCreditCard && !methodConfig.disable)))

methodConfig.disable não existe e por isso sempre dá true, passando a existir, quando for true, não vai passar por cartão de crédido, acredito eu.