### PR TITLE
chore(list-payments): add interest free min amount for each installment

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -311,6 +311,13 @@ const app = {
               default: 0,
               title: 'Taxa de juros',
               description: 'Juros percentual total, zero para sem juros'
+            },
+            interest_free_min_amount: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 999999999,
+              title: 'Mínimo sem juros',
+              description: 'Montante mínimo para parcelamento sem juros'
             }
           }
         }

--- a/functions/routes/ecom/modules/list-payments.js
+++ b/functions/routes/ecom/modules/list-payments.js
@@ -132,13 +132,13 @@ exports.post = ({ appSdk }, req, res) => {
           // optional configured installments list
           if (amount.total && Array.isArray(config.installments) && config.installments.length) {
             gateway.installment_options = []
-            config.installments.forEach(({ number, interest }) => {
+            config.installments.forEach(({ number, interest, interest_free_min_amount }) => {
               if (number >= 2) {
                 const value = amount.total / number
                 if (value >= minInstallment) {
                   gateway.installment_options.push({
                     number,
-                    value: interest > 0 ? value + value * interest / 100 : value,
+                    value: interest > 0 && (!interest_free_min_amount || interest_free_min_amount < amount.total) ? value + value * interest / 100 : value,
                     tax: Boolean(interest)
                   })
                 }


### PR DESCRIPTION
O mercado pago agora tem uma configuração que o lojista consegue colocar valor mínimo por parcelamento sem jurso:

![image](https://user-images.githubusercontent.com/35343551/234424793-a49dd164-970d-4e5c-be23-470619ea32ba.png)

Então a ideia é o cara que quer fazer esse tipo de situação, configura o % de parcelamento em 2x por exemplo e também configura o minimo pra parcelamento sem juros.Se passar do valor mínimo, parcelamento sem juros, se não tiver, com juros.. como no checkout após colocar 6 dígitos busca o que vem do mp, então, precisa ter essa "sincronia"
