### PR TITLE
fix(create-transaction): use only 2 decimals to avoid invalid amount

### DIFF
--- a/functions/routes/ecom/modules/create-transaction.js
+++ b/functions/routes/ecom/modules/create-transaction.js
@@ -105,7 +105,7 @@ exports.post = ({ appSdk, admin }, req, res) => {
       }
     },
     external_reference: String(params.order_number),
-    transaction_amount: params.amount.total,
+    transaction_amount: Number(params.amount.total.toFixed(2)),
     description: `Pedido #${params.order_number} de ${buyer.fullname}`.substring(0, 60),
     payment_method_id: paymentMethodId,
     token,

--- a/functions/routes/ecom/modules/create-transaction.js
+++ b/functions/routes/ecom/modules/create-transaction.js
@@ -105,7 +105,7 @@ exports.post = ({ appSdk, admin }, req, res) => {
       }
     },
     external_reference: String(params.order_number),
-    transaction_amount: Number(params.amount.total.toFixed(2)),
+    transaction_amount: Math.round(params.amount.total * 100) / 100,
     description: `Pedido #${params.order_number} de ${buyer.fullname}`.substring(0, 60),
     payment_method_id: paymentMethodId,
     token,


### PR DESCRIPTION
Nos pedidos feitos ai com loyalty points principalmente, o amount.total está ficando com multiplas casas demais e ai o mercado pago entende como valor inválido. Já tive pedido aqui com valor em 2 casas, normal, mas passando disso, dá erro.