### PR TITLE
fix: infer CPF/CNPJ identification type from doc digit count

### DIFF
--- a/functions/public/onload-expression.js
+++ b/functions/public/onload-expression.js
@@ -112,13 +112,12 @@
         }
       }
 
-      // todo
-      // - select typeDoc
       var $typeDoc = document.createElement('select');
       $typeDoc.setAttribute('data-checkout', 'docType')
       var $typeDocOption = document.createElement('option');
-      $typeDocOption.text = customer.registry_type === 'j' ? 'CNPJ' : 'CPF'
-      $typeDocOption.value = customer.registry_type === 'j' ? 'CNPJ' : 'CPF'
+      var docType = String(mpParams.docNumber).replace(/\D/g, '').length === 14 ? 'CNPJ' : 'CPF'
+      $typeDocOption.text = docType
+      $typeDocOption.value = docType
       $typeDocOption.setAttribute('selected', true)
       $typeDoc.add($typeDocOption)
 

--- a/functions/routes/ecom/modules/create-transaction.js
+++ b/functions/routes/ecom/modules/create-transaction.js
@@ -108,7 +108,7 @@ exports.post = ({ appSdk, admin }, req, res) => {
       first_name: payerOrBuyer.fullname.replace(/\s.*/, ''),
       last_name: payerOrBuyer.fullname.replace(/[^\s]+\s/, ''),
       identification: {
-        type: payerOrBuyer.registry_type === 'j' ? 'CNPJ' : 'CPF',
+        type: String(payerOrBuyer.doc_number).replace(/\D/g, '').length === 14 ? 'CNPJ' : 'CPF',
         number: String(payerOrBuyer.doc_number)
       }
     },


### PR DESCRIPTION
Replace registry_type-based identification.type with digit-count inference: 11 digits = CPF, 14 digits = CNPJ. Fixes tokenization and payment creation for PJ customers paying with a personal CPF card.

Needed for [this](https://github.com/ecomplus/storefront/pull/1282) to work