### PR TITLE
fix(list-payments): load MP device fingerprint script to reduce false cc_rejected_high_risk

### DIFF
--- a/functions/routes/ecom/modules/list-payments.js
+++ b/functions/routes/ecom/modules/list-payments.js
@@ -107,7 +107,13 @@ exports.post = ({ appSdk }, req, res) => {
         }
         gateway.js_client = {
           script_uri: 'https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js',
+          // load MP's device fingerprint script so `window.MP_DEVICE_SESSION_ID` is set
+          // (consumed as `X-meli-session-id` on create-transaction), required for risk analysis
+          // https://www.mercadopago.com.br/developers/pt/docs/checkout-pro/how-tos/improve-payment-approval/recommendations
           onload_expression: `window.Mercadopago.setPublishableKey("${config.mp_public_key}");` +
+            'if(!window.__mpSecurityLoaded){window.__mpSecurityLoaded=true;' +
+            'var s=document.createElement("script");s.src="https://www.mercadopago.com/v2/security.js";' +
+            's.setAttribute("view","checkout");document.head.appendChild(s);}' +
             fs.readFileSync(path.join(__dirname, '../../../public/onload-expression.min.js'), 'utf8'),
           cc_brand: {
             function: '_mpBrand',


### PR DESCRIPTION
## Problem

Credit card checkouts never load Mercado Pago's `security.js`, so `window.MP_DEVICE_SESSION_ID` is always unset and `X-meli-session-id` is never sent on `create-transaction` — even though that header has been implemented and consumed there since `9a98b98` (Dec 2022).

Per [MP's own recommendations](https://www.mercadopago.com.br/developers/pt/docs/checkout-pro/how-tos/improve-payment-approval/recommendations), a missing device fingerprint significantly increases false-positive `cc_rejected_high_risk` declines, since payments here are POSTed server-side (data-center IP, no buyer device context to infer).

Observed on a production store using this app: **72% decline rate over the last 30 days** (vs. ~15% historical baseline), with the most recent declines all sharing `status_detail: cc_rejected_high_risk` and `authorization_code`/`date_approved` null — meaning the transaction is blocked before ever reaching the card issuer.

This isn't store-specific: the same gap (`deviceId: window.MP_DEVICE_SESSION_ID || 0`, no `security.js` load anywhere) also exists in `packages/apps/mercadopago` on `ecomplus/cloud-commerce`.

## Fix

Inject MP's official `security.js` script from `js_client.onload_expression`. `container_html` can't be used for this — the storefront renders it via `innerHTML` (`PaymentMethods.js`), which does not execute `<script>` tags. `onload_expression` runs through `eval` (`load-payment-client.js`), so it can safely create and append a real script element.

No other logic changes — `create-transaction.js` already sends the header once `deviceId` is populated.

## Verification

- `npx eslint routes/ecom/modules/list-payments.js` — 0 new errors/warnings
- Simulated the handler locally (with the real `uglify-js` minification step) and confirmed:
  - the injected snippet appears correctly in the generated `onload_expression`
  - the resulting string is valid, parseable JS
  - final length is 2401/3000 chars, within the Mods API schema limit for `onload_expression`

## Risk

Low and additive:
- If `security.js` fails to load or is blocked, `deviceId` falls back to `0` exactly like today — no regression path.
- Guarded with `window.__mpSecurityLoaded` to avoid re-injecting the script if the shopper toggles payment methods.
- Does not touch `create-transaction.js` or any payment-processing logic.